### PR TITLE
fix(tests): Add a test case for where exit code is specified as a string

### DIFF
--- a/tests/dependencies.json
+++ b/tests/dependencies.json
@@ -11,6 +11,12 @@
       "exit_code": 17
     }
   },
+  "exit 17 wait_for string": {
+    "cmd": ["./fixtures/exit-17.sh"],
+    "wait_for": {
+      "exit_code": "17"
+    }
+  },
   "take too long": {
     "cmd": ["./fixtures/take-too-long.sh"],
     "wait_for": {

--- a/tests/test.js
+++ b/tests/test.js
@@ -37,6 +37,8 @@ test('test SIGKILL', require('../')(['catch-signals']));
 
 test('wait for exit code', require('../')('exit 17'));
 
+test('wait for exit code specified by string', require('../')('exit 17 wait_for string'));
+
 test('timeout', function(t) {
   require('../')('take too long')(function(err) {
     t.ok(err, "error returned on timeout");


### PR DESCRIPTION
Just to be sure it works.
