### PR TITLE
fix(wait on exit code): Properly exit when waiting for a zero exit code

### DIFF
--- a/index.js
+++ b/index.js
@@ -331,7 +331,7 @@ Dependency.prototype.waitOnExit = function(callback) {
   callback = _.once(callback);
   async.until(function() {
     last = new Date().getTime() - start;
-    return self.child.exitCode || (last > self.what.wait_for.timeout * 1000)
+    return self.child.exitCode || self.child.exitCode === 0 || (last > self.what.wait_for.timeout * 1000)
   }, function(callback) {
     _.delay(callback, 101);
   }, function(err) {

--- a/tests/dependencies.json
+++ b/tests/dependencies.json
@@ -20,6 +20,12 @@
   "true": {
     "cmd": ["true"]
   },
+  "exit 0": {
+    "cmd": ["./fixtures/exit-0.sh"],
+    "wait_for": {
+      "exit_code": 0
+    }
+  },
   "exit 17": {
     "cmd": ["./fixtures/exit-17.sh"],
     "wait_for": {

--- a/tests/fixtures/exit-0.sh
+++ b/tests/fixtures/exit-0.sh
@@ -1,0 +1,3 @@
+#! /usr/bin/env bash
+sleep 1
+exit 0

--- a/tests/test.js
+++ b/tests/test.js
@@ -36,6 +36,7 @@ test('pass in a tree from a different file, see evil fail', function(t) {
 test('test SIGKILL', require('../')(['catch-signals']));
 
 test('wait for exit code', require('../')('exit 17'));
+test('wait for exit code zero', require('../')('exit 0'));
 
 test('wait for exit code specified by string', require('../')('exit 17 wait_for string'));
 


### PR DESCRIPTION
Currently we are checking for the truthiness of `child.exitCode` or checking if the timeout has elapsed before continuing on. This doesn't work when waiting for an exit code of 0.
