### PR TITLE
feature(log truncation): Allow logs to be truncated.

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,8 @@ var _ = require('underscore');
 var resolve = require('resolve');
 var autotarget = require('async-autotarget');
 
+var truncatedStdioMap = {};
+
 exports = module.exports = function depends_on(targets, tree) {
   var d = get_dependencies(tree);
   return d.get_ready(targets);
@@ -207,6 +209,18 @@ Dependency.prototype.spawn = function(test, callback) {
     return;
   }
   this.spawned = true;
+
+  if (this.what.truncateStdio && !truncatedStdioMap[this.name]) {
+    try {
+      fs.truncateSync(this.what.stdout, 0);
+      fs.truncateSync(this.what.stderr, 0);
+    } catch (e) {
+      if (e.code !== 'ENOENT') {
+        throw e;
+      }
+    }
+    truncatedStdioMap[this.name] = true;
+  }
 
   this.child = spawn(cmd, args, {
     'cwd': this.what.cwd,

--- a/index.js
+++ b/index.js
@@ -7,8 +7,6 @@ var _ = require('underscore');
 var resolve = require('resolve');
 var autotarget = require('async-autotarget');
 
-var truncatedStdioMap = {};
-
 exports = module.exports = function depends_on(targets, tree) {
   var d = get_dependencies(tree);
   return d.get_ready(targets);
@@ -189,7 +187,8 @@ Dependency.prototype.spawn = function(test, callback) {
   var
     self = this,
     cmd = this.what.cmd[0],
-    args = this.what.cmd.slice(1);
+    args = this.what.cmd.slice(1),
+    openMode = 'a';
 
   this.test = test;
 
@@ -210,23 +209,15 @@ Dependency.prototype.spawn = function(test, callback) {
   }
   this.spawned = true;
 
-  if (this.what.truncateStdio && !truncatedStdioMap[this.name]) {
-    try {
-      fs.truncateSync(this.what.stdout, 0);
-      fs.truncateSync(this.what.stderr, 0);
-    } catch (e) {
-      if (e.code !== 'ENOENT') {
-        throw e;
-      }
-    }
-    truncatedStdioMap[this.name] = true;
+  if (this.what.truncateStdio) {
+    openMode = 'w'
   }
 
   this.child = spawn(cmd, args, {
     'cwd': this.what.cwd,
     'stdio': [ 0,
-      this.what.stdout && fs.openSync(this.what.stdout, 'a') || 1,
-      this.what.stderr && fs.openSync(this.what.stderr, 'a') || 2]
+      this.what.stdout && fs.openSync(this.what.stdout, openMode) || 1,
+      this.what.stderr && fs.openSync(this.what.stderr, openMode) || 2]
   });
 
   this.child.unref(); // don't block the event loop, children will be signalled on exit

--- a/tests/dependencies.json
+++ b/tests/dependencies.json
@@ -88,5 +88,16 @@
     "cmd": ["./fixtures/catch-signals.js"],
     "stdout": "./logs/catch-signals.log",
     "signal": "SIGKILL"
+  },
+  "truncate stdio": {
+    "cmd": ["./fixtures/truncate-stdio.sh"],
+    "stdout": "./logs/truncate-stdout",
+    "stderr": "./logs/truncate-stderr",
+    "truncateStdio": true
+  },
+  "do not truncate stdio": {
+    "cmd": ["./fixtures/truncate-stdio.sh"],
+    "stdout": "./logs/truncate-stdout",
+    "stderr": "./logs/truncate-stderr"
   }
 }

--- a/tests/fixtures/truncate-stdio.sh
+++ b/tests/fixtures/truncate-stdio.sh
@@ -1,0 +1,4 @@
+#! /bin/bash
+
+echo "hello bluefish"
+echo "hello redfish" >&2

--- a/tests/test.js
+++ b/tests/test.js
@@ -4,7 +4,6 @@ var path = require('path');
 require('longjohn');
 var ready = require('..')('true'); // for the process.on('exit', …); to be before tape's
 var test = require('tape');
-var async = require('async');
 
 test('ready', ready);
 

--- a/tests/test.js
+++ b/tests/test.js
@@ -1,7 +1,10 @@
+var fs = require('fs');
+var path = require('path');
 
 require('longjohn');
 var ready = require('..')('true'); // for the process.on('exit', …); to be before tape's
 var test = require('tape');
+var async = require('async');
 
 test('ready', ready);
 
@@ -47,4 +50,36 @@ test('timeout', function(t) {
   });
 });
 
+test('truncate stdio', function(t) {
+  fs.writeFileSync(path.resolve(__dirname, 'logs/truncate-stdout'), 'hello bluefish\n');
+  fs.writeFileSync(path.resolve(__dirname, 'logs/truncate-stderr'), 'hello redfish\n');
 
+  require('..')('truncate stdio')(function(err) {
+    var stdout, stderr;
+
+    t.ifError(err);
+
+    stdout = fs.readFileSync(path.resolve(__dirname, 'logs/truncate-stdout')).toString();
+    stderr = fs.readFileSync(path.resolve(__dirname, 'logs/truncate-stderr')).toString();
+    t.equal(stdout, 'hello bluefish\n', 'stdout only had a single line and was truncated.');
+    t.equal(stderr, 'hello redfish\n', 'stderr only had a single line and was truncated.');
+    t.end();
+  });
+});
+
+test('do not truncate stdio', function(t) {
+  fs.writeFileSync(path.resolve(__dirname, 'logs/truncate-stdout'), 'hello bluefish\n');
+  fs.writeFileSync(path.resolve(__dirname, 'logs/truncate-stderr'), 'hello redfish\n');
+
+  require('..')('do not truncate stdio')(function(err) {
+    var stdout, stderr;
+
+    t.ifError(err);
+
+    stdout = fs.readFileSync(path.resolve(__dirname, 'logs/truncate-stdout')).toString();
+    stderr = fs.readFileSync(path.resolve(__dirname, 'logs/truncate-stderr')).toString();
+    t.equal(stdout, 'hello bluefish\nhello bluefish\n', 'stdout had multiple lines and was not truncated.');
+    t.equal(stderr, 'hello redfish\nhello redfish\n', 'stderr had multiple lines and was truncated.');
+    t.end();
+  });
+});


### PR DESCRIPTION
This allows dependency targets to specify whether or not their
logs(stdout, stderr) should be truncated before the first time they are
started up within the same process that depends-on runs.

If a depends-on target is used multiple times within the life of a
process, the log will only be truncated once.

Targets can add this by specifying the `truncateStdio` flag to `true` in
their configuration.
